### PR TITLE
Fix order of board updates in move apply/undo methods

### DIFF
--- a/src/aiChess/model/MoveFactory.java
+++ b/src/aiChess/model/MoveFactory.java
@@ -52,19 +52,19 @@ final class MoveFactory {
       this.moveStatus = sourcePiece.get().hasMoved();
       sourcePiece.get().setMoved(true);
 
-      /* move source piece to target location */
-      model.setPieceAt(targetPos.row, targetPos.col, sourcePiece);
       /* make source location empty */
       model.setPieceAt(sourcePos.row, sourcePos.col, Optional.empty());
+      /* move source piece to target location */
+      model.setPieceAt(targetPos.row, targetPos.col, sourcePiece);
     }
 
     @Override
     void undo(BoardModel model) {
       Optional<Piece> sourcePiece = model.getPieceAt(targetPos.row, targetPos.col);
-      /* move source piece to source location */
-      model.setPieceAt(sourcePos.row, sourcePos.col, sourcePiece);
       /* move saved target piece to target location */
       model.setPieceAt(targetPos.row, targetPos.col, this.targetPiece);
+      /* move source piece to source location */
+      model.setPieceAt(sourcePos.row, sourcePos.col, sourcePiece);
       /* clear saved info from last apply */
       targetPiece = Optional.empty();
       this.lastApplied = false;

--- a/test/aiChess/model/MoveFactoryTest.java
+++ b/test/aiChess/model/MoveFactoryTest.java
@@ -27,6 +27,41 @@ public class MoveFactoryTest {
    * - the move logic does not care about the specific type of piece
    * - top player's pieces will be written as uppercase in comments. */ 
 
+  /* test move with source == target */
+  @Test
+  public void testSelfMove() {
+    // _ K
+    // _ _ 
+    var pos11 = new Position(1, 1); 
+    var king = Optional.of(PieceFactory.makePiece(PieceType.KING, PlayerType.TOP_PLAYER));
+    var move = MoveFactory.makeRegularMove(pos11, pos11);
+    this.board.setPieceAt(1, 1, king);
+
+    move.apply(this.board);
+    for (int row = 0; row < board.height; row += 1) {
+      for (int col = 0; col < board.width; col += 1) {
+        var pos = new Position(row, col);
+        if (row == 1 && col == 1) {
+          assertEquals("king tile at " + pos, king, board.getPieceAt(row, col));
+        } else {
+          assertEquals("empty tile at " + pos, Optional.empty(), board.getPieceAt(row, col));
+        }
+      }
+    }
+
+    move.undo(this.board);
+    for (int row = 0; row < board.height; row += 1) {
+      for (int col = 0; col < board.width; col += 1) {
+        var pos = new Position(row, col);
+        if (row == 1 && col == 1) {
+          assertEquals("king tile at " + pos, king, board.getPieceAt(row, col));
+        } else {
+          assertEquals("empty tile at " + pos, Optional.empty(), board.getPieceAt(row, col));
+        }
+      }
+    }
+  }
+
 
   /* test apply and undo methods of regular move */
   @Test


### PR DESCRIPTION
As itself, there is nothing that prevents a Move to have the same source and target position, although current move pieces won't generate such a move. 

However, since such condition is not forbidden by the move API, and it won't break the behavior of existing application, it should be handled properly.